### PR TITLE
replace method_missing by define_method for redis-rb

### DIFF
--- a/lib/unified_redis/adapters/redis.rb
+++ b/lib/unified_redis/adapters/redis.rb
@@ -3,13 +3,15 @@ module UnifiedRedis
   module Adapter
     class Redis
       def initialize(redis)
-        @redis = redis
-      end
-
-      def method_missing(command, *args)
-        result = @redis.send(command, *args)
-        yield result if block_given?
-        return result
+        redis.class.instance_methods(false).each do |command|
+          self.class.instance_eval do
+            define_method command do |*args|
+              result = redis.send(command, *args)
+              yield result if block_given?
+              return result
+            end
+          end
+        end
       end
     end
   end

--- a/lib/unified_redis/adapters/redis.rb
+++ b/lib/unified_redis/adapters/redis.rb
@@ -3,14 +3,14 @@ module UnifiedRedis
   module Adapter
     class Redis
       def initialize(redis)
-        redis.class.instance_methods(false).each do |command|
-          self.class.instance_eval do
-            define_method command do |*args|
-              result = redis.send(command, *args)
-              yield result if block_given?
-              return result
-            end
-          end
+        @redis = redis
+      end
+
+      ::Redis.instance_methods(false).each do |command|
+        define_method command do |*args|
+          result = @redis.send(command, *args)
+          yield result if block_given?
+          return result
         end
       end
     end


### PR DESCRIPTION
This commit replace method_missing by define_method for Redis adapter.

chatgris
